### PR TITLE
Add overview dashboard context and README narrative

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,13 @@
 
 **Real numbers for magical brands**
 
-Find out the bottom-line impact of your brand marketing efforts by connecting your audience data with your customer data to get a real-time picture of how your brand influences your growth.
+Brand lets teams prove that community building and storytelling translate into revenue. Import an audience list (a Substack export, TikTok follower sync, Instagram or LinkedIn connection list, etc.) and overlap it with your customer or pipeline data from Shopify, HubSpot, Salesforce, and other revenue systems. The result is a single place to measure how brand activity drives pipeline, purchase events, and lifetime value.
+
+### Product overview
+
+- **Audience ↔ Customer Overlap**: Upload or connect both sides to instantly see how many community members are already customers, where the white space is, and which accounts belong in ABM plays.
+- **Engagement to Revenue Lift**: Track how engagement moments map to orders, revenue lift windows, and LTV differences (e.g., “followers who comment on IG are 2.5× more likely to buy within a week”).
+- **Pipeline Opportunities**: Surface prospects that follow your brand but aren’t yet in your CRM stage, highlighting the best next conversations for sales and partnerships teams.
 
 ## 🚀 Features
 

--- a/dashboard-customer-table.html
+++ b/dashboard-customer-table.html
@@ -31,13 +31,106 @@
 
 <div id="content" class="dashboard" style="gap: 0px;">
   <div class="header-tabs">
-    <h4 class="active" data-tab="customers">Customers (CRM)</h4>
+    <h4 class="active" data-tab="overview">Overview</h4>
+    <h4 data-tab="customers">Customers (CRM)</h4>
     <h4 data-tab="insights">Insights (Data)</h4>
   </div>
-  
+
+  <!-- Overview Tab Content -->
+  <div id="overview-content" class="tab-content active">
+    <div class="table-container">
+      <div class="overview-summary">
+        <div class="overview-visual">
+          <img src="img/venn.png" alt="Overlap between audience and customers" />
+          <p class="venn-caption">Audience &amp; customer overlap — refreshed nightly</p>
+        </div>
+        <div class="overview-metrics">
+          <div class="metrics-grid">
+            <div class="metric-card">
+              <span class="metric-label">Total audience</span>
+              <span class="metric-value">48,214</span>
+              <span class="metric-subtext">connected followers &amp; subscribers</span>
+            </div>
+            <div class="metric-card">
+              <span class="metric-label">Customers</span>
+              <span class="metric-value">12,487</span>
+              <span class="metric-subtext">Shopify &amp; Salesforce combined</span>
+            </div>
+            <div class="metric-card">
+              <span class="metric-label">Audience → customer overlap</span>
+              <span class="metric-value">6,932</span>
+              <span class="metric-subtext">14% of total audience</span>
+            </div>
+            <div class="metric-card">
+              <span class="metric-label">Warm pipeline</span>
+              <span class="metric-value">1,118</span>
+              <span class="metric-subtext">followers not yet in CRM stages</span>
+            </div>
+          </div>
+          <div class="metrics-grid secondary">
+            <div class="metric-card">
+              <span class="metric-label">Engagement lift</span>
+              <span class="metric-value">2.5×</span>
+              <span class="metric-subtext">likelihood to purchase within 7 days after IG interactions</span>
+            </div>
+            <div class="metric-card">
+              <span class="metric-label">Avg. LTV uplift</span>
+              <span class="metric-value">+38%</span>
+              <span class="metric-subtext">audience-aligned customers vs baseline</span>
+            </div>
+            <div class="metric-card">
+              <span class="metric-label">New ABM targets</span>
+              <span class="metric-value">47</span>
+              <span class="metric-subtext">execs engaging on LinkedIn last week</span>
+            </div>
+            <div class="metric-card">
+              <span class="metric-label">Churn risk</span>
+              <span class="metric-value">3.1%</span>
+              <span class="metric-subtext">customers with no engagement in 90 days</span>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="overview-highlights">
+        <h5>Highlights</h5>
+        <ul>
+          <li>Top creators in your audience who are not yet customers are queued for outreach in the table below.</li>
+          <li>Engagement lift metrics are placeholders and will be updated once attribution modeling is connected.</li>
+          <li>Use the tabs to drill into platform-specific overlap once data sources are synced.</li>
+        </ul>
+      </div>
+
+      <div class="table-tabs">
+        <div class="tab active">Top audience</div>
+        <div class="tab">All audience</div>
+        <div class="tab">Instagram</div>
+        <div class="tab">TikTok</div>
+        <div class="tab">Substack</div>
+      </div>
+      <table id="overview-table" class="all-audience-table">
+        <thead>
+          <tr>
+            <th>#</th>
+            <th>Name</th>
+            <th>About</th>
+            <th>Tag</th>
+            <th>Following</th>
+            <th>Start date</th>
+            <th>Active score</th>
+            <th>Influence</th>
+          </tr>
+        </thead>
+        <tbody>
+          <!-- Data will be loaded via DataTables -->
+        </tbody>
+      </table>
+    </div>
+  </div>
+
   <!-- Customers Tab Content -->
-  <div id="customers-content" class="tab-content active">
-    <div id="customer-table">
+  <div id="customers-content" class="tab-content">
+    <div class="table-container">
       <div class="table-tabs">
         <div class="tab active">Top audience</div>
         <div class="tab">All audience</div>
@@ -67,7 +160,7 @@
   
   <!-- Insights Tab Content -->
   <div id="insights-content" class="tab-content">
-    <div id="customer-table">
+    <div class="table-container">
       <div class="table-tabs">
         <div class="tab active">Overview</div>
         <div class="tab">Revenue</div>

--- a/main.js
+++ b/main.js
@@ -573,70 +573,78 @@ function startLoadingAnimation() {
 
 // DataTables initialization
 function initializeDataTables() {
-    // Check if we're on the dashboard page and DataTables is available
-    const customersTable = document.getElementById('customers-table');
-    if (!customersTable || typeof $ === 'undefined' || typeof $.fn.DataTable === 'undefined') {
+    // Ensure DataTables is available
+    if (typeof $ === 'undefined' || typeof $.fn.DataTable === 'undefined') {
         return;
     }
-    
-    // Initialize DataTable with AJAX data source - minimal styling
-    const table = $('#customers-table').DataTable({
-        ajax: {
-            url: 'data/customers.json',
-            dataSrc: 'data'
-        },
-        columns: [
-            { 
-                data: 'initials',
-                render: function(data, type, row) {
-                    return '<span class="initials-avatar">' + data + '</span>';
-                }
-            },
-            { data: 'name' },
-            { data: 'about' },
-            { 
-                data: 'tag',
-                render: function(data, type, row) {
-                    return '<span class="tag-pill ' + row.tag_type + '">' + data + '</span>';
-                }
-            },
-            { data: 'following' },
-            { data: 'start_date' },
-            { 
-                data: 'active_score',
-                render: function(data, type, row) {
-                    let stars = '';
-                    for (let i = 1; i <= 5; i++) {
-                        const filled = i <= data ? 'filled' : '';
-                        stars += '<span class="star ' + filled + '">★</span>';
-                    }
-                    return '<div class="star-rating">' + stars + '</div>';
-                }
-            },
-            { data: 'influence' }
-        ],
-        // Hide DataTables controls for clean look
-        dom: 'rt', // Only show table and processing
-        paging: false, // No pagination
-        searching: false, // No search box
-        info: false, // No info text
-        lengthChange: false, // No length menu
-        ordering: false, // No sorting functionality
-        responsive: true,
-        columnDefs: [
-            {
-                targets: [0, 4, 7], // #, Following, Influence columns
-                className: 'dt-body-center'
-            }
-        ]
-    });
-    
-    // Add click handler for table rows to show customer modal
-    $('#customers-table tbody').on('click', 'tr', function() {
-        const data = table.row(this).data();
-        if (data) {
-            showCustomerModal(data);
+
+    const tableConfigs = [
+        { selector: '#overview-table', dataUrl: 'data/customers.json' },
+        { selector: '#customers-table', dataUrl: 'data/customers.json' }
+    ];
+
+    tableConfigs.forEach(config => {
+        const tableElement = document.querySelector(config.selector);
+        if (!tableElement) {
+            return;
         }
+
+        const dataTable = $(config.selector).DataTable({
+            ajax: {
+                url: config.dataUrl,
+                dataSrc: 'data'
+            },
+            columns: [
+                {
+                    data: 'initials',
+                    render: function(data) {
+                        return '<span class="initials-avatar">' + data + '</span>';
+                    }
+                },
+                { data: 'name' },
+                { data: 'about' },
+                {
+                    data: 'tag',
+                    render: function(data, type, row) {
+                        return '<span class="tag-pill ' + row.tag_type + '">' + data + '</span>';
+                    }
+                },
+                { data: 'following' },
+                { data: 'start_date' },
+                {
+                    data: 'active_score',
+                    render: function(data) {
+                        let stars = '';
+                        for (let i = 1; i <= 5; i++) {
+                            const filled = i <= data ? 'filled' : '';
+                            stars += '<span class="star ' + filled + '">★</span>';
+                        }
+                        return '<div class="star-rating">' + stars + '</div>';
+                    }
+                },
+                { data: 'influence' }
+            ],
+            dom: 'rt',
+            paging: false,
+            searching: false,
+            info: false,
+            lengthChange: false,
+            ordering: false,
+            responsive: true,
+            columnDefs: [
+                {
+                    targets: [0, 4, 7],
+                    className: 'dt-body-center'
+                }
+            ]
+        });
+
+        $(config.selector + ' tbody').on('click', 'tr', function() {
+            const data = dataTable.row(this).data();
+            if (data) {
+                showCustomerModal(data);
+            }
+        });
     });
 }
 

--- a/style.css
+++ b/style.css
@@ -479,11 +479,11 @@ form input[type="url"]::placeholder {
 }
 
 /* Customer table styles */
-#customer-table { 
-  background-color: #ffffff; 
-  padding: 50px; 
-  border-radius: none; 
-  border: 1px solid #cdcdcd;  
+.table-container {
+  background-color: #ffffff;
+  padding: 50px;
+  border-radius: 0;
+  border: 1px solid #cdcdcd;
 }
 
 .header-tabs, .table-tabs { 
@@ -527,8 +527,111 @@ form input[type="url"]::placeholder {
   cursor: pointer; 
 }
 
-.table-tabs .active { 
-  border-bottom: 2px solid #cdcdcd; 
+.table-tabs .active {
+  border-bottom: 2px solid #cdcdcd;
+}
+
+.overview-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 30px;
+  align-items: stretch;
+  margin-bottom: 30px;
+}
+
+.overview-visual {
+  flex: 1 1 280px;
+  background: #f6f6f6;
+  border: 1px solid #cdcdcd;
+  border-radius: 8px;
+  padding: 30px 25px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 15px;
+}
+
+.overview-visual img {
+  width: 100%;
+  max-width: 320px;
+  height: auto;
+}
+
+.venn-caption {
+  font-size: 14px;
+  color: #555;
+  text-align: center;
+  font-family: 'Comic Neue', cursive;
+}
+
+.overview-metrics {
+  flex: 2 1 460px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+}
+
+.metrics-grid.secondary {
+  opacity: 0.9;
+}
+
+.metric-card {
+  background: #fff;
+  border: 1px solid #ddd;
+  border-radius: 8px;
+  padding: 20px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-height: 140px;
+}
+
+.metric-card .metric-label {
+  font-size: 13px;
+  letter-spacing: 0.5px;
+}
+
+.metric-card .metric-value {
+  font-size: 28px;
+  font-weight: 600;
+}
+
+.metric-subtext {
+  font-size: 12px;
+  color: #666;
+  font-family: 'Comic Neue', cursive;
+  line-height: 1.4;
+}
+
+.overview-highlights {
+  background: #f9f9f9;
+  border: 1px dashed #cdcdcd;
+  border-radius: 8px;
+  padding: 20px 25px;
+  margin-bottom: 30px;
+}
+
+.overview-highlights h5 {
+  margin: 0 0 12px;
+  font-size: 20px;
+  font-weight: 500;
+}
+
+.overview-highlights ul {
+  margin: 0;
+  padding-left: 22px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 14px;
+  color: #333;
 }
 
 /* Table styles */


### PR DESCRIPTION
## Summary
- expand the README introduction with product context about overlapping audience and customer data to prove ROI
- add an Overview tab to the dashboard with venn-diagram placeholders, summary metrics, highlights, and a mirrored audience table
- update shared styles and DataTables initialization so the new overview layout matches the CRM experience

## Testing
- not run (static assets only)


------
https://chatgpt.com/codex/tasks/task_e_68cdca74b87c8321b37310de0525b4f0